### PR TITLE
Compare pciids

### DIFF
--- a/src/librpminspect/inspect.h
+++ b/src/librpminspect/inspect.h
@@ -67,6 +67,13 @@ bool inspect_elf(struct rpminspect *);
 bool compare_module_parameters(const struct kmod_list *, const struct kmod_list *, string_list_t **);
 bool compare_module_dependencies(const struct kmod_list *, const struct kmod_list *, string_list_t **, string_list_t **);
 
+struct kernel_alias_data;
+typedef void (*module_alias_callback)(const char *, const string_list_t *, const string_list_t *, void *);
+
+void gather_module_aliases(const char *, const struct kmod_list *, struct kernel_alias_data **);
+void free_module_aliases(struct kernel_alias_data *);
+bool compare_module_aliases(struct kernel_alias_data *, struct kernel_alias_data *, module_alias_callback, void *);
+
 /* inspect_license.c */
 void free_licensedb(void);
 bool is_valid_license(const char *, const char *);

--- a/src/librpminspect/inspect_kernel.c
+++ b/src/librpminspect/inspect_kernel.c
@@ -19,6 +19,8 @@
 #include "config.h"
 
 #include <assert.h>
+#include <fnmatch.h>
+#include <search.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -201,4 +203,302 @@ bool compare_module_dependencies(const struct kmod_list *before, const struct km
     *after_deps = after_depends_list;
 
     return false;
+}
+
+
+/* Module alias regression checking */
+
+/* mapping of an alias string to a module name */
+struct _alias_entry_t {
+    char *alias;
+    char *module;
+    TAILQ_ENTRY(_alias_entry_t) items;
+};
+
+TAILQ_HEAD(_alias_list_t, _alias_entry_t);
+
+struct kernel_alias_data {
+    size_t num_aliases;
+    struct _alias_list_t *alias_list;
+    struct hsearch_data *alias_table;
+};
+
+/* Add a module's alias information to a kernel_alias_data collection.
+ *
+ * Pass NULL as *output to create a new kernel_alias_data object. When done, the
+ * data must be freed with free_module_aliases.
+ */
+void gather_module_aliases(const char *module_name, const struct kmod_list *modinfo_list, struct kernel_alias_data **output)
+{
+    const struct kmod_list *iter = NULL;
+    const char *key;
+    const char *value;
+    struct _alias_entry_t *alias_entry;
+
+    assert(module_name);
+    assert(modinfo_list);
+    assert(output);
+
+    if (*output == NULL) {
+        *output = calloc(1, sizeof(*output));
+        assert(*output);
+
+        (*output)->alias_list = calloc(1, sizeof(*((*output)->alias_list)));
+        assert((*output)->alias_list);
+
+        TAILQ_INIT((*output)->alias_list);
+    }
+
+    kmod_list_foreach(iter, modinfo_list) {
+        /* Only gather pci aliases */
+        key = kmod_module_info_get_key(iter);
+
+        if (strcmp(key, "alias") != 0) {
+            continue;
+        }
+
+        value = kmod_module_info_get_value(iter);
+
+        if (!strprefix(value, "pci:")) {
+            continue;
+        }
+
+        alias_entry = calloc(1, sizeof(*alias_entry));
+        assert(alias_entry);
+
+        alias_entry->alias = strdup(value);
+        assert(alias_entry->alias);
+
+        alias_entry->module = strdup(module_name);
+        assert(alias_entry->module);
+
+        (*output)->num_aliases++;
+        TAILQ_INSERT_TAIL((*output)->alias_list, alias_entry, items);
+    }
+}
+
+/* Free the kernel_alias_data struct created by gather_module_aliases */
+void free_module_aliases(struct kernel_alias_data *data)
+{
+    struct _alias_entry_t *alias_entry;
+    ENTRY e;
+    ENTRY *eptr;
+
+    if (data == NULL) {
+        return;
+    }
+
+    while (!TAILQ_EMPTY(data->alias_list)) {
+        alias_entry = TAILQ_FIRST(data->alias_list);
+        TAILQ_REMOVE(data->alias_list, alias_entry, items);
+
+        if (data->alias_table != NULL) {
+            e.key = alias_entry->alias;
+            hsearch_r(e, FIND, &eptr, data->alias_table);
+
+            if ((eptr != NULL) && (eptr->data != NULL)) {
+                list_free((string_list_t *) eptr->data, free);
+                eptr->data = NULL;
+            }
+        }
+
+        free(alias_entry->alias);
+        free(alias_entry->module);
+        free(alias_entry);
+    }
+
+    free(data->alias_list);
+
+    if (data->alias_table != NULL) {
+        hdestroy_r(data->alias_table);
+        free(data->alias_table);
+    }
+
+    free(data);
+}
+
+static void _finalize_module_aliases(struct kernel_alias_data *data)
+{
+    struct _alias_entry_t *alias_entry;
+    struct _alias_entry_t *tmp;
+    ENTRY e;
+    ENTRY *eptr;
+    string_entry_t *module_entry;
+    int result;
+
+    assert(data);
+
+    data->alias_table = calloc(1, sizeof(*(data->alias_table)));
+    assert(data->alias_table);
+
+    /*
+     * The glibc man page for hcreate recommends a size 25% greater than
+     * the number of elements, so use that
+     */
+    result = hcreate_r(data->num_aliases * 1.25, data->alias_table);
+    assert(result != 0);
+
+    alias_entry = TAILQ_FIRST(data->alias_list);
+    while (alias_entry != NULL) {
+        /* Create a new entry for the alias -> module-list mapping */
+        module_entry = calloc(1, sizeof(*module_entry));
+        assert(module_entry);
+
+        module_entry->data = strdup(alias_entry->module);
+        assert(module_entry->data);
+
+        /* Find or insert the alias */
+        e.key = alias_entry->alias;
+        e.data = NULL;
+        result = hsearch_r(e, ENTER, &eptr, data->alias_table);
+        assert(result != 0);
+
+        if (eptr->data != NULL) {
+            /* The alias was already in the table. First, add this module name to the list in "data" */
+            TAILQ_INSERT_TAIL((string_list_t *) eptr->data, module_entry, items);
+
+            /* Now delete this duplicate alias entry from alias_list */
+            tmp = TAILQ_NEXT(alias_entry, items);
+            TAILQ_REMOVE(data->alias_list, alias_entry, items);
+
+            free(alias_entry->alias);
+            free(alias_entry->module);
+            free(alias_entry);
+
+            /* Advance past the deleted entry */
+            alias_entry = tmp;
+        } else {
+            /* The alias was not in the table, start a new module name list */
+            eptr->data = calloc(1, sizeof(string_list_t));
+            assert(eptr->data);
+
+            TAILQ_INIT((string_list_t *) eptr->data);
+            TAILQ_INSERT_TAIL((string_list_t *) eptr->data, module_entry, items);
+
+            /* Advance to the next entry */
+            alias_entry = TAILQ_NEXT(alias_entry, items);
+        }
+    }
+}
+
+static string_list_t * _wildcard_alias_search(const char *alias, const struct _alias_list_t *after_aliases)
+{
+    string_list_t *result;
+    string_entry_t *entry;
+    struct _alias_entry_t *iter;
+
+    result = calloc(1, sizeof(*result));
+    assert(result);
+    TAILQ_INIT(result);
+
+    TAILQ_FOREACH(iter, after_aliases, items) {
+        if (fnmatch(iter->alias, alias, 0) == 0) {
+            entry = calloc(1, sizeof(*entry));
+            assert(entry);
+
+            entry->data = strdup(iter->module);
+            assert(entry->data);
+
+            TAILQ_INSERT_TAIL(result, entry, items);
+        }
+    }
+
+    return result;
+}
+
+/* For each module alias in "before", ensure that the alias is provided by the same modules in "after".
+ * If "after" lost providers, call the provided callback with the before and after lists, and return false.
+ *
+ * Module aliases use glob-style wildcards, so not all changes in strings are a regression. For example,
+ * in 2.6.25, cxgb3 changed all of its sub-device values to '*', so "pci:v00001425d00000020sv*sd00000001bc*sc*i*"
+ * became "pci:v00001425d00000020sv*sd*bc*sc*i*". The after string still matches the before string, so this is
+ * not a regression.
+ *
+ * However, since matching up module aliases does involve arbitrary-length wildcards, this function effectively
+ * needs to run fnmatch() between every combination of before and after aliases, resulting in a complexity of O(n^2).
+ * To speed things up in the (hopefully) usual case, the wildcard search is only run when an exact string match of
+ * an alias (using hash tables) results in an apparent regression.
+ */
+bool compare_module_aliases(struct kernel_alias_data *before, struct kernel_alias_data *after, module_alias_callback callback, void *user_data)
+{
+    struct _alias_entry_t *iter;
+    string_list_t *before_modules;
+    string_list_t *after_modules;
+    string_list_t *difference;
+    string_list_t empty;
+    ENTRY e;
+    ENTRY *eptr;
+    bool wildcard_search;
+    bool result = true;
+
+    assert(callback);
+
+    /* Before empty, nothing to check for */
+    if (before == NULL) {
+        return true;
+    }
+
+    /* If after is NULL, fake the results with an empty list */
+    if (after == NULL) {
+        TAILQ_INIT(&empty);
+    }
+
+    /* Gather the lists of aliases into hash tables, mapping an alias string to a string_list_t of module names. */
+    _finalize_module_aliases(before);
+
+    if (after != NULL) {
+        _finalize_module_aliases(after);
+    }
+
+    /* For each alias in before, look for the matching alias in after */
+    TAILQ_FOREACH(iter, before->alias_list, items) {
+        e.key = iter->alias;
+        hsearch_r(e, FIND, &eptr, before->alias_table);
+        assert(eptr != NULL);
+        before_modules = (string_list_t *) eptr->data;
+
+        /*
+         * If the after list was NULL, no need to do a wildcard search. Just call the
+         * function with an empty after list.
+         */
+        if (after == NULL) {
+            callback(iter->alias, before_modules, &empty, user_data);
+            continue;
+        }
+
+        hsearch_r(e, FIND, &eptr, after->alias_table);
+        wildcard_search = false;
+
+        /* No match found, do a wildcard search */
+        if (eptr == NULL) {
+            after_modules = _wildcard_alias_search(iter->alias, after->alias_list);
+            wildcard_search = true;
+        } else {
+            after_modules = (string_list_t *) eptr->data;
+            difference = list_difference(before_modules, after_modules);
+
+            /* If the lists differ, do a wildcard search */
+            if (!TAILQ_EMPTY(difference)) {
+                after_modules = _wildcard_alias_search(iter->alias, after->alias_list);
+                wildcard_search = true;
+            }
+
+            list_free(difference, NULL);
+        }
+
+        /* Compare the results */
+        difference = list_difference(before_modules, after_modules);
+
+        if (!TAILQ_EMPTY(difference)) {
+            callback(iter->alias, before_modules, after_modules, user_data);
+            result = false;
+        }
+
+        /* If after_modules was created from a wildcard search, free it */
+        if (wildcard_search) {
+            list_free(after_modules, NULL);
+        }
+    }
+
+    return result;
 }

--- a/src/librpminspect/listfuncs.c
+++ b/src/librpminspect/listfuncs.c
@@ -39,6 +39,10 @@ static struct hsearch_data * list_to_table(const string_list_t *list)
     /* Iterate over the list once to get the size */
     table_size = list_len(list);
 
+    if (table_size == 0) {
+        table_size = 1;
+    }
+
     /* Allocate the table */
     table = calloc(1, sizeof(*table));
     assert(table != NULL);
@@ -169,6 +173,10 @@ string_list_t * list_union(const string_list_t *a, const string_list_t *b)
 
     u_table_size += list_len(a);
     u_table_size += list_len(b);
+
+    if (u_table_size == 0) {
+        u_table_size = 1;
+    }
 
     if (!hcreate_r(u_table_size, &u_table)) {
         fprintf(stderr, "Unable to create hash table: %s\n", strerror(errno));

--- a/src/librpminspect/listfuncs.c
+++ b/src/librpminspect/listfuncs.c
@@ -178,6 +178,8 @@ string_list_t * list_union(const string_list_t *a, const string_list_t *b)
         u_table_size = 1;
     }
 
+    memset(&u_table, 0, sizeof(u_table));
+
     if (!hcreate_r(u_table_size, &u_table)) {
         fprintf(stderr, "Unable to create hash table: %s\n", strerror(errno));
         return NULL;


### PR DESCRIPTION
This implements the utility functions for checking for module PCI alias regressions, along with a couple of bug fixes to listfuncs.c.

This is not part of an inspection driver yet. I guess it could be, since it doesn't depend on creating file-level peers like the other module checks do, but I figured it would make more sense for all of the module checks to go in the same inspection.