### PR TITLE
Badwords and misc tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 script:
   - $DOCKER_RUN ./autogen.sh
-  - $DOCKER_RUN ./configure --enable-code-coverage --enable-valgrind
+  - $DOCKER_RUN env CFLAGS="-O2 -Wall -Wextra -Werror" ./configure --enable-code-coverage --enable-valgrind
 
   # Stop after the first failure, to keep the output more readable
   - |

--- a/src/librpminspect/files.c
+++ b/src/librpminspect/files.c
@@ -474,8 +474,6 @@ void find_file_peers(rpmfile_t *before, rpmfile_t *after)
     rpmfile_entry_t *iter;
     rpmfile_entry_t *after_entry;
 
-    int result = -1;
-
     assert(before != NULL);
     assert(after != NULL);
 

--- a/src/librpminspect/init.c
+++ b/src/librpminspect/init.c
@@ -131,23 +131,18 @@ int init_rpminspect(struct rpminspect *ri, const char *cfgfile) {
         /* make a copy of the string for splitting */
         start = walk = strdup(tmp);
 
-        /* split up the string of bad words and turn them in to regexps */
+        /* split up the string of bad words and turn them in to a list */
         ri->badwords = calloc(1, sizeof(*(ri->badwords)));
         assert(ri->badwords != NULL);
         TAILQ_INIT(ri->badwords);
 
-        /* convert each word to a regexp and add it to the list */
         while ((badword = strsep(&walk, " \t")) != NULL) {
-            /* create the first pattern with a beginning word boundary */
             entry = calloc(1, sizeof(*entry));
             assert(entry != NULL);
-            xasprintf(&entry->data, "\\b%s", badword);
-            TAILQ_INSERT_TAIL(ri->badwords, entry, items);
 
-            /* create the second pattern with an ending word boundary */
-            entry = calloc(1, sizeof(*entry));
-            assert(entry != NULL);
-            xasprintf(&entry->data, "%s\\b", badword);
+            entry->data = strdup(badword);
+            assert(entry->data != NULL);
+
             TAILQ_INSERT_TAIL(ri->badwords, entry, items);
         }
 

--- a/src/librpminspect/inspect_desktop.c
+++ b/src/librpminspect/inspect_desktop.c
@@ -32,7 +32,7 @@ static char *file_to_find = NULL;
 /*
  * Helper used by nftw() in _validate_desktop_contents()
  */
-static int _find_file(const char *fpath, const struct stat *sb, int tflag, struct FTW *ftwbuf) {
+static int _find_file(const char *fpath, __attribute__((unused)) const struct stat *sb, int tflag, __attribute__((unused)) struct FTW *ftwbuf) {
     /* Only looking at regular files */
     if (tflag != FTW_F) {
         return 0;
@@ -81,7 +81,6 @@ static bool _is_desktop_entry_file(const char *desktop_entry_files_dir, const rp
 static int _validate_desktop_file(const char *tool, const char *fullpath, char **result) {
     int ret;
     char *cmd = NULL;
-    char *out = NULL;
     char *new = NULL;
     char buf[BUFSIZ];
     FILE *cmdfp = NULL;
@@ -282,7 +281,6 @@ static bool _validate_desktop_contents(struct rpminspect *ri, const rpmfile_entr
 static bool _desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
     bool result = true;
     int after_code;
-    int before_code;
     char *after_out = NULL;
     char *before_out = NULL;
     char *msg = NULL;
@@ -301,7 +299,7 @@ static bool _desktop_driver(struct rpminspect *ri, rpmfile_entry_t *file) {
 
     if (file->peer_file && _is_desktop_entry_file(ri->desktop_entry_files_dir, file->peer_file)) {
         /* if we have a before peer, validate the corresponding desktop file */
-        before_code = _validate_desktop_file(ri->desktop_file_validate, file->peer_file->fullpath, &before_out);
+        (void) _validate_desktop_file(ri->desktop_file_validate, file->peer_file->fullpath, &before_out);
     }
 
     if (after_code == -1) {

--- a/src/librpminspect/inspect_elf.c
+++ b/src/librpminspect/inspect_elf.c
@@ -615,6 +615,9 @@ static bool _check_fortified(struct rpminspect *ri, Elf *before_elf, Elf *after_
     char *msg;
     bool result = true;
 
+    /* ignore unused variable warnings if assert is disabled */
+    (void) output_result;
+
     /* If "before" had no fortified symbols, it can't lose fortified symbols. Return. */
     before_fortified = get_fortified_symbols(before_elf);
     assert(before_fortified != NULL);
@@ -801,6 +804,9 @@ static bool _elf_archive_tests(struct rpminspect *ri, Elf *after_elf, int after_
 
     char *msg = NULL;
     bool result = true;
+
+    /* ignore unused variable warnings if assert is disabled */
+    (void) output_result;
 
     /* comparison-only, skip if no before */
     if (!before_elf) {

--- a/src/librpminspect/inspect_elf.c
+++ b/src/librpminspect/inspect_elf.c
@@ -935,7 +935,6 @@ static bool _elf_regular_tests(struct rpminspect *ri, Elf *after_elf, Elf *befor
 
 static bool _elf_driver(struct rpminspect *ri, rpmfile_entry_t *after)
 {
-    const char *localpath;
     const char *arch;
     Elf *after_elf = NULL;
     Elf *before_elf = NULL;

--- a/src/librpminspect/inspect_kernel.c
+++ b/src/librpminspect/inspect_kernel.c
@@ -326,6 +326,9 @@ static void _finalize_module_aliases(struct kernel_alias_data *data)
     string_entry_t *module_entry;
     int result;
 
+    /* ignore unused variable warnings if assert is disabled */
+    (void) result;
+
     assert(data);
 
     data->alias_table = calloc(1, sizeof(*(data->alias_table)));

--- a/src/librpminspect/inspect_license.c
+++ b/src/librpminspect/inspect_license.c
@@ -109,6 +109,9 @@ static int _check_peer_license(struct rpminspect *ri, const Header hdr) {
 void free_licensedb(void) {
     int r;
 
+    /* ignore unused variable warnings if assert is disabled */
+    (void) r;
+
     if (licdb == NULL) {
         return;
     }

--- a/src/librpminspect/inspect_metadata.c
+++ b/src/librpminspect/inspect_metadata.c
@@ -26,9 +26,7 @@
 /*
  * Validate the metadata tags in the RPM headers.
  */
-static bool _valid_peers(struct rpminspect *ri,
-                         const Header before_hdr, const char *before_rpm,
-                         const Header after_hdr, const char *after_rpm) {
+static bool _valid_peers(struct rpminspect *ri, const Header before_hdr, const Header after_hdr) {
     bool ret = true;
     char *after_vendor = NULL;
     char *after_buildhost = NULL;
@@ -39,7 +37,6 @@ static bool _valid_peers(struct rpminspect *ri,
     char *dump = NULL;
 
     assert(ri != NULL);
-    assert(after_rpm != NULL);
 
     after_nevra = headerGetAsString(after_hdr, RPMTAG_NEVRA);
 
@@ -85,7 +82,7 @@ static bool _valid_peers(struct rpminspect *ri,
         free(msg);
     }
 
-    if (before_rpm != NULL) {
+    if (before_hdr != NULL) {
         char *before_vendor = headerGetAsString(before_hdr, RPMTAG_VENDOR);
         char *before_summary = headerGetAsString(before_hdr, RPMTAG_SUMMARY);
         char *before_description = headerGetAsString(before_hdr, RPMTAG_DESCRIPTION);
@@ -145,7 +142,7 @@ bool inspect_metadata(struct rpminspect *ri) {
      */
 
     /* Check the source peers */
-    if (!_valid_peers(ri, ri->before_srpm_hdr, ri->before_srpm, ri->after_srpm_hdr, ri->after_srpm)) {
+    if (!_valid_peers(ri, ri->before_srpm_hdr, ri->after_srpm_hdr)) {
         ret = true;
     }
 
@@ -156,7 +153,7 @@ bool inspect_metadata(struct rpminspect *ri) {
             continue;
         }
 
-        if (!_valid_peers(ri, peer->before_hdr, peer->before_rpm, peer->after_hdr, peer->after_rpm)) {
+        if (!_valid_peers(ri, peer->before_hdr, peer->after_hdr)) {
             ret = true;
         }
     }

--- a/src/librpminspect/local.c
+++ b/src/librpminspect/local.c
@@ -36,6 +36,9 @@ bool is_local_build(const char *build) {
     char *r = NULL;
     struct stat sb;
 
+    /* ignore unused variable warnings if assert is disabled */
+    (void) r;
+
     if (build == NULL) {
         return false;
     }

--- a/src/librpminspect/readelf.c
+++ b/src/librpminspect/readelf.c
@@ -42,6 +42,9 @@ Elf64_Half get_elf_type(Elf *elf)
     GElf_Ehdr ehdr;
     GElf_Ehdr *eh = NULL;
 
+    /* ignore unused variable warnings if assert is disabled */
+    (void) eh;
+
     eh = gelf_getehdr(elf, &ehdr);
     assert(eh != NULL);
 

--- a/src/librpminspect/rmtree.c
+++ b/src/librpminspect/rmtree.c
@@ -30,11 +30,9 @@
 /* Local prototypes */
 static int _rmtree_entry(const char *, const struct stat *, int, struct FTW *);
 
-static int _rmtree_entry(const char *fpath, const struct stat *sb,
-                         int tflag, struct FTW *ftwbuf) {
-    assert(sb != NULL);
-    assert(tflag >= 0);
-    assert(ftwbuf != NULL);
+static int _rmtree_entry(const char *fpath, __attribute__((unused)) const struct stat *sb,
+                         __attribute__((unused)) int tflag, __attribute__((unused)) struct FTW *ftwbuf) {
+    assert(fpath != NULL);
     return remove(fpath);
 }
 

--- a/src/librpminspect/rpminspect.h
+++ b/src/librpminspect/rpminspect.h
@@ -42,12 +42,23 @@ extern struct inspect inspections[];
 extern struct format formats[];
 
 /* Macros */
+#ifdef NDEBUG
+/* Don't create unused variables if not using assert() */
+#define xasprintf(dest, ...) {                   \
+    *(dest) = NULL;                              \
+    asprintf((dest), __VA_ARGS__);               \
+}
+
+#else
+
 #define xasprintf(dest, ...) {                   \
     int _xasprintf_result;                       \
     *(dest) = NULL;                              \
     _xasprintf_result = asprintf((dest), __VA_ARGS__);\
     assert(_xasprintf_result != -1);             \
 }
+
+#endif
 
 /*
  * Build identifier strings (used in paths)

--- a/src/rpminspect/builds.c
+++ b/src/rpminspect/builds.c
@@ -159,6 +159,10 @@ static int _download_rpms(struct koji_build *build) {
     int r;
     CURLcode cc;
 
+    /* ignore unusued variable warnings if assert is disabled */
+    (void) r;
+    (void) cc;
+
     assert(build != NULL);
     assert(build->rpms != NULL);
 

--- a/tests/librpminspect/Makefile.am
+++ b/tests/librpminspect/Makefile.am
@@ -29,9 +29,11 @@ noinst_PROGRAMS = execstack noexecstack
 
 execstack_SOURCES = elftest.c
 execstack_CFLAGS = -z execstack -z relro
+execstack_LDFLAGS = -no-install
 
 noexecstack_SOURCES = elftest.c
 noexecstack_CFLAGS = -z noexecstack -z relro
+noexecstack_LDFLAGS = -no-install
 
 EXTRA_DIST = test-main.h
 else

--- a/tests/librpminspect/Makefile.am
+++ b/tests/librpminspect/Makefile.am
@@ -4,14 +4,16 @@ if HAVE_CUNIT
 # Add the check-valgrind target
 @VALGRIND_CHECK_RULES@
 
-TESTS = $(check_PROGRAMS)
+TESTS = test-badwords \
+	test-koji \
+	test-tty \
+	test-strfuncs \
+	test-init \
+	test-inspect_elf
 
-check_PROGRAMS = test-badwords \
-                 test-koji \
-                 test-tty \
-                 test-strfuncs \
-                 test-init \
-                 test-inspect_elf
+check_PROGRAMS = $(TESTS) \
+		 execstack \
+		 noexecstack
 
 CFLAGS += -I$(top_srcdir)/src/librpminspect -D_BUILDDIR_=\"$(abs_builddir)\"
 LDADD = $(top_builddir)/src/librpminspect/librpminspect.la $(CUNIT_LIBS)
@@ -25,8 +27,6 @@ test_inspect_elf_SOURCES = test-inspect_elf.c test-main.c
 
 # Used by the inspect_elf tests
 # Compile elftest.c in a bunch of different ways for the ELF tests
-noinst_PROGRAMS = execstack noexecstack
-
 execstack_SOURCES = elftest.c
 execstack_CFLAGS = -z execstack -z relro
 execstack_LDFLAGS = -no-install

--- a/tests/librpminspect/elftest.c
+++ b/tests/librpminspect/elftest.c
@@ -23,7 +23,7 @@ int some_function(void) {
     return 47;
 }
 
-int main(int argc, char **argv) {
+int main(void) {
     char *s = "Hello, world.";
     printf("%s\n", s);
     return EXIT_SUCCESS;

--- a/tests/librpminspect/test-badwords.c
+++ b/tests/librpminspect/test-badwords.c
@@ -83,6 +83,13 @@ void test_has_bad_word(void) {
     RI_ASSERT(has_bad_word("cocacola", forbidden_words) == false);
     RI_ASSERT(has_bad_word("suse", forbidden_words) == false);
     RI_ASSERT(has_bad_word("supermonkeyball", forbidden_words) == false);
+
+    /* Ensure bad words match at the start or end of a word, but not the middle */
+    RI_ASSERT(has_bad_word("bazzing", forbidden_words) == true);
+    RI_ASSERT(has_bad_word("is bazzing", forbidden_words) == true);
+    RI_ASSERT(has_bad_word("motherbaz", forbidden_words) == true);
+    RI_ASSERT(has_bad_word("motherbaz other words", forbidden_words) == true);
+    RI_ASSERT(has_bad_word("bebazzled", forbidden_words) == false);
 }
 
 CU_pSuite get_suite(void) {

--- a/tests/librpminspect/test-inspect_elf.c
+++ b/tests/librpminspect/test-inspect_elf.c
@@ -45,7 +45,7 @@ void test_is_execstack_present(void) {
     Elf *elf;
 
     /* expected true */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -57,7 +57,7 @@ void test_is_execstack_present(void) {
     RI_ASSERT_EQUAL(close(fd), 0);
 
     /* expected false */
-    fd = open(_BUILDDIR_"/.libs/noexecstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/noexecstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -76,7 +76,7 @@ void test_get_execstack_flags(void) {
     Elf *elf;
 
     /* expected non-zero return */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -88,7 +88,7 @@ void test_get_execstack_flags(void) {
     RI_ASSERT_EQUAL(close(fd), 0);
 
     /* expected zero return */
-    fd = open(_BUILDDIR_"/.libs/noexecstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/noexecstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -107,7 +107,7 @@ void test_has_executable_program(void) {
     Elf *elf;
 
     /* expected true */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -126,7 +126,7 @@ void test_is_execstack_valid(void) {
     Elf *elf;
 
     /* expect true */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -145,7 +145,7 @@ void test_is_stack_executable(void) {
     Elf *elf;
 
     /* expect true */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -157,7 +157,7 @@ void test_is_stack_executable(void) {
     RI_ASSERT_EQUAL(close(fd), 0);
 
     /* expect false */
-    fd = open(_BUILDDIR_"/.libs/noexecstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/noexecstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -176,7 +176,7 @@ void test_has_textrel(void) {
     Elf *elf;
 
     /* expect false */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -195,7 +195,7 @@ void test_has_relro(void) {
     Elf *elf;
 
     /* expect true */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -214,7 +214,7 @@ void test_has_bind_now(void) {
     Elf *elf;
 
     /* expect false */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);
@@ -243,7 +243,7 @@ void test_is_pic_ok(void) {
     Elf *elf;
 
     /* expect true */
-    fd = open(_BUILDDIR_"/.libs/execstack", O_RDONLY);
+    fd = open(_BUILDDIR_"/execstack", O_RDONLY);
     RI_ASSERT_NOT_EQUAL(fd, -1);
 
     elf = elf_begin(fd, ELF_C_READ_MMAP_PRIVATE, NULL);


### PR DESCRIPTION
Change the badwords implementation to not use regexes, since there's no real reason to use them and it just adds another layer of complexity.

Also clean up a couple of things with the tests.