### PR TITLE
Strip extra () after bugfix for issue #19

### DIFF
--- a/src/librpminspect/files.c
+++ b/src/librpminspect/files.c
@@ -245,7 +245,7 @@ rpmfile_t * extract_rpm(const char *pkg, Header hdr)
         }
 
         /* Write the file to disk */
-        if ((archive_read_extract(archive, entry, archive_flags) != ARCHIVE_OK)) {
+        if (archive_read_extract(archive, entry, archive_flags) != ARCHIVE_OK) {
             fprintf(stderr, "*** Error extracting %s: %s\n", pkg, archive_error_string(archive));
             free_files(file_list);
             file_list = NULL;


### PR DESCRIPTION
Noticed we had some extra parentheses after the bugfix in issue #19 so this strips those back out.